### PR TITLE
Sorted env vars alphabetically

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 )
 
@@ -20,6 +21,7 @@ func main() {
 			pair := strings.Split(e, "=")
 			res.EnvVars = append(res.EnvVars, pair[0]+"="+pair[1])
 		}
+		sort.Strings(res.EnvVars)
 
 		for i := 1; i <= 90; i++ {
 			res.Fib = append(res.Fib, f())


### PR DESCRIPTION
This sorts env vars alphabetically so that it's a bit easier to see the power of k8s service discovery env vars.

ie.
```
    "ECSDEMO_CRYSTAL_PORT=tcp://10.100.55.49:80",
    "ECSDEMO_CRYSTAL_PORT_80_TCP=tcp://10.100.55.49:80",
    "ECSDEMO_CRYSTAL_PORT_80_TCP_ADDR=10.100.55.49",
    "ECSDEMO_CRYSTAL_PORT_80_TCP_PORT=80",
    "ECSDEMO_CRYSTAL_PORT_80_TCP_PROTO=tcp",
    "ECSDEMO_CRYSTAL_SERVICE_HOST=10.100.55.49",
    "ECSDEMO_CRYSTAL_SERVICE_PORT=80",
    "ECSDEMO_FRONTEND_PORT=tcp://10.100.113.108:80",
    "ECSDEMO_FRONTEND_PORT_80_TCP=tcp://10.100.113.108:80",
    "ECSDEMO_FRONTEND_PORT_80_TCP_ADDR=10.100.113.108",
    "ECSDEMO_FRONTEND_PORT_80_TCP_PORT=80",
    "ECSDEMO_FRONTEND_PORT_80_TCP_PROTO=tcp",
    "ECSDEMO_FRONTEND_SERVICE_HOST=10.100.113.108",
    "ECSDEMO_FRONTEND_SERVICE_PORT=80",
    "ECSDEMO_NODEJS_PORT=tcp://10.100.169.93:80",
    "ECSDEMO_NODEJS_PORT_80_TCP=tcp://10.100.169.93:80",
    "ECSDEMO_NODEJS_PORT_80_TCP_ADDR=10.100.169.93",
    "ECSDEMO_NODEJS_PORT_80_TCP_PORT=80",
    "ECSDEMO_NODEJS_PORT_80_TCP_PROTO=tcp",
    "ECSDEMO_NODEJS_SERVICE_HOST=10.100.169.93",
    "ECSDEMO_NODEJS_SERVICE_PORT=80",
    "HELLO_K8S_PORT=tcp://10.100.55.3:80",
    "HELLO_K8S_PORT_80_TCP=tcp://10.100.55.3:80",
    "HELLO_K8S_PORT_80_TCP_ADDR=10.100.55.3",
    "HELLO_K8S_PORT_80_TCP_PORT=80",
    "HELLO_K8S_PORT_80_TCP_PROTO=tcp",
    "HELLO_K8S_SERVICE_HOST=10.100.55.3",
    "HELLO_K8S_SERVICE_PORT=80",
    "HOME=/home/app",
    "HOSTNAME=hello-k8s-6d7d77d9-gts8f",
    "KUBERNETES_PORT=tcp://10.100.0.1:443",
    "KUBERNETES_PORT_443_TCP=tcp://10.100.0.1:443",
    "KUBERNETES_PORT_443_TCP_ADDR=10.100.0.1",
    "KUBERNETES_PORT_443_TCP_PORT=443",
    "KUBERNETES_PORT_443_TCP_PROTO=tcp",
    "KUBERNETES_SERVICE_HOST=10.100.0.1",
    "KUBERNETES_SERVICE_PORT=443",
    "KUBERNETES_SERVICE_PORT_HTTPS=443",
    "MYWEBSERVER_NGINX_PORT=tcp://10.100.145.21:80",
    "MYWEBSERVER_NGINX_PORT_80_TCP=tcp://10.100.145.21:80",
    "MYWEBSERVER_NGINX_PORT_80_TCP_ADDR=10.100.145.21",
    "MYWEBSERVER_NGINX_PORT_80_TCP_PORT=80",
    "MYWEBSERVER_NGINX_PORT_80_TCP_PROTO=tcp",
    "MYWEBSERVER_NGINX_SERVICE_HOST=10.100.145.21",
    "MYWEBSERVER_NGINX_SERVICE_PORT=80",
    "MYWEBSERVER_NGINX_SERVICE_PORT_HTTP=80",
    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
    "PHP_APACHE_PORT=tcp://10.100.30.27:80",
    "PHP_APACHE_PORT_80_TCP=tcp://10.100.30.27:80",
    "PHP_APACHE_PORT_80_TCP_ADDR=10.100.30.27",
    "PHP_APACHE_PORT_80_TCP_PORT=80",
    "PHP_APACHE_PORT_80_TCP_PROTO=tcp",
    "PHP_APACHE_SERVICE_HOST=10.100.30.27",
    "PHP_APACHE_SERVICE_PORT=80"
```
instead of 
```
    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
    "HOSTNAME=hello-k8s-7597cb655c-s2hgh",
    "KUBERNETES_SERVICE_HOST=10.100.0.1",
    "ECSDEMO_NODEJS_PORT_80_TCP_PORT=80",
    "KUBERNETES_PORT_443_TCP_PROTO=tcp",
    "ECSDEMO_FRONTEND_PORT_80_TCP_ADDR=10.100.113.108",
    "ECSDEMO_NODEJS_SERVICE_HOST=10.100.169.93",
    "MYWEBSERVER_NGINX_PORT_80_TCP=tcp://10.100.145.21:80",
    "MYWEBSERVER_NGINX_PORT_80_TCP_PORT=80",
    "PHP_APACHE_SERVICE_PORT=80",
    "PHP_APACHE_PORT_80_TCP_PROTO=tcp",
    "KUBERNETES_PORT_443_TCP=tcp://10.100.0.1:443",
    "HELLO_K8S_SERVICE_PORT=80",
    "MYWEBSERVER_NGINX_SERVICE_PORT=80",
    "MYWEBSERVER_NGINX_PORT_80_TCP_PROTO=tcp",
    "PHP_APACHE_PORT=tcp://10.100.30.27:80",
    "KUBERNETES_SERVICE_PORT=443",
    "HELLO_K8S_PORT_80_TCP_PROTO=tcp",
    "ECSDEMO_NODEJS_SERVICE_PORT=80",
    "PHP_APACHE_PORT_80_TCP=tcp://10.100.30.27:80",
    "PHP_APACHE_PORT_80_TCP_ADDR=10.100.30.27",
    "KUBERNETES_PORT_443_TCP_PORT=443",
    "KUBERNETES_PORT_443_TCP_ADDR=10.100.0.1",
    "ECSDEMO_FRONTEND_SERVICE_PORT=80",
    "ECSDEMO_FRONTEND_PORT=tcp://10.100.113.108:80",
    "ECSDEMO_FRONTEND_PORT_80_TCP=tcp://10.100.113.108:80",
    "ECSDEMO_FRONTEND_PORT_80_TCP_PROTO=tcp",
    "ECSDEMO_FRONTEND_PORT_80_TCP_PORT=80",
    "ECSDEMO_CRYSTAL_SERVICE_PORT=80",
    "ECSDEMO_CRYSTAL_PORT_80_TCP_PORT=80",
    "ECSDEMO_CRYSTAL_PORT_80_TCP_ADDR=10.100.55.49",
    "ECSDEMO_NODEJS_PORT_80_TCP=tcp://10.100.169.93:80",
    "MYWEBSERVER_NGINX_PORT_80_TCP_ADDR=10.100.145.21",
    "PHP_APACHE_PORT_80_TCP_PORT=80",
    "KUBERNETES_PORT=tcp://10.100.0.1:443",
    "ECSDEMO_CRYSTAL_PORT_80_TCP=tcp://10.100.55.49:80",
    "ECSDEMO_NODEJS_PORT_80_TCP_PROTO=tcp",
    "ECSDEMO_NODEJS_PORT_80_TCP_ADDR=10.100.169.93",
    "MYWEBSERVER_NGINX_SERVICE_PORT_HTTP=80",
    "KUBERNETES_SERVICE_PORT_HTTPS=443",
    "HELLO_K8S_PORT=tcp://10.100.55.3:80",
    "HELLO_K8S_PORT_80_TCP=tcp://10.100.55.3:80",
    "HELLO_K8S_PORT_80_TCP_PORT=80",
    "ECSDEMO_CRYSTAL_SERVICE_HOST=10.100.55.49",
    "MYWEBSERVER_NGINX_SERVICE_HOST=10.100.145.21",
    "MYWEBSERVER_NGINX_PORT=tcp://10.100.145.21:80",
    "HELLO_K8S_SERVICE_HOST=10.100.55.3",
    "HELLO_K8S_PORT_80_TCP_ADDR=10.100.55.3",
    "ECSDEMO_FRONTEND_SERVICE_HOST=10.100.113.108",
    "ECSDEMO_CRYSTAL_PORT=tcp://10.100.55.49:80",
    "ECSDEMO_CRYSTAL_PORT_80_TCP_PROTO=tcp",
    "ECSDEMO_NODEJS_PORT=tcp://10.100.169.93:80",
    "PHP_APACHE_SERVICE_HOST=10.100.30.27",
    "HOME=/home/app"
```