### PR TITLE
Fix for Python 3.4 incompatibility with aws cli 1.19

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,7 +7,7 @@ phases:
       - curl -sS -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
       - chmod +x ./kubectl ./aws-iam-authenticator
       - export PATH=$PWD/:$PATH
-      - apt-get update && apt-get -y install jq python3-pip python3-dev && pip3 install --upgrade awscli
+      - sudo apt-get update && apt-get -y install jq python3-pip python3-dev && pip3 install --upgrade awscli
   pre_build:
       commands:
         - TAG="$REPOSITORY_NAME.$REPOSITORY_BRANCH.$ENVIRONMENT_NAME.$(date +%Y-%m-%d.%H.%M.%S).$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | head -c 8)"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,6 +17,7 @@ phases:
         - export KUBECONFIG=$HOME/.kube/config
   build:
     commands:
+      - docker login -u ekslabaccount -p 76700ac2-6b4d-4211-89f9-e0bacd318ef0
       - docker build --tag $REPOSITORY_URI:$TAG .
 
   post_build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,7 +8,7 @@ phases:
       - chmod +x ./kubectl ./aws-iam-authenticator
       - export PATH=$PWD/:$PATH
       - apt-get update && apt-get -y install jq python3-pip python3-dev
-      - pip3 install awscli<1.18 --upgrade
+      - pip3 install 'awscli<1.18' --upgrade
   pre_build:
       commands:
         - TAG="$REPOSITORY_NAME.$REPOSITORY_BRANCH.$ENVIRONMENT_NAME.$(date +%Y-%m-%d.%H.%M.%S).$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | head -c 8)"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -33,3 +33,4 @@ phases:
       - printf '[{"name":"hello-k8s","imageUri":"%s"}]' $REPOSITORY_URI:$TAG > build.json
 artifacts:
   files: build.json
+

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,7 +7,8 @@ phases:
       - curl -sS -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
       - chmod +x ./kubectl ./aws-iam-authenticator
       - export PATH=$PWD/:$PATH
-      - sudo apt-get update && apt-get -y install jq python3-pip python3-dev && pip3 install --upgrade awscli
+      - apt-get update && apt-get -y install jq python3-pip python3-dev && pip3 install --upgrade awscli
+      - cat /root/.pip/pip.log
   pre_build:
       commands:
         - TAG="$REPOSITORY_NAME.$REPOSITORY_BRANCH.$ENVIRONMENT_NAME.$(date +%Y-%m-%d.%H.%M.%S).$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | head -c 8)"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,7 +8,7 @@ phases:
       - chmod +x ./kubectl ./aws-iam-authenticator
       - export PATH=$PWD/:$PATH
       - apt-get update && apt-get -y install jq python3-pip python3-dev
-      - pip3 install --upgrade awscli
+      - pip3 install awscli<1.18 --upgrade
   pre_build:
       commands:
         - TAG="$REPOSITORY_NAME.$REPOSITORY_BRANCH.$ENVIRONMENT_NAME.$(date +%Y-%m-%d.%H.%M.%S).$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | head -c 8)"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,8 +7,8 @@ phases:
       - curl -sS -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl
       - chmod +x ./kubectl ./aws-iam-authenticator
       - export PATH=$PWD/:$PATH
-      - apt-get update && apt-get -y install jq python3-pip python3-dev && pip3 install --upgrade awscli
-      - cat /root/.pip/pip.log
+      - apt-get update && apt-get -y install jq python3-pip python3-dev
+      - pip3 install --upgrade awscli
   pre_build:
       commands:
         - TAG="$REPOSITORY_NAME.$REPOSITORY_BRANCH.$ENVIRONMENT_NAME.$(date +%Y-%m-%d.%H.%M.%S).$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | head -c 8)"

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 
 		f := fib()
 
-		res := &response{Message: "Hello World"}
+		res := &response{Message: "Hello World!"}
 
 		for _, e := range os.Environ() {
 			pair := strings.Split(e, "=")

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 
 		f := fib()
 
-		res := &response{Message: "Hello World!"}
+		res := &response{Message: "Hello World!!"}
 
 		for _, e := range os.Environ() {
 			pair := strings.Split(e, "=")

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 
 		f := fib()
 
-		res := &response{Message: "Hello World!!"}
+		res := &response{Message: "Hello World!!!"}
 
 		for _, e := range os.Environ() {
 			pair := strings.Split(e, "=")

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 
 		f := fib()
 
-		res := &response{Message: "Update to Feature v1.1"}
+		res := &response{Message: "Update to Feature v1.2"}
 
 		for _, e := range os.Environ() {
 			pair := strings.Split(e, "=")

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 
 		f := fib()
 
-		res := &response{Message: "Hello World!!!!!!!!!!!!!!!"}
+		res := &response{Message: "Hello World"}
 
 		for _, e := range os.Environ() {
 			pair := strings.Split(e, "=")

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 
 		f := fib()
 
-		res := &response{Message: "Hello World!!!"}
+		res := &response{Message: "Hello World!!!!!!!!!!"}
 
 		for _, e := range os.Environ() {
 			pair := strings.Split(e, "=")

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 
 		f := fib()
 
-		res := &response{Message: "Update to Feature"}
+		res := &response{Message: "Update to Feature v1.1"}
 
 		for _, e := range os.Environ() {
 			pair := strings.Split(e, "=")

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 
 		f := fib()
 
-		res := &response{Message: "Hello World"}
+		res := &response{Message: "Hello World!!!!!!!!!!!!!!!"}
 
 		for _, e := range os.Environ() {
 			pair := strings.Split(e, "=")

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 
 		f := fib()
 
-		res := &response{Message: "Commit Change!!!!!!!!!!"}
+		res := &response{Message: "Update to Feature"}
 
 		for _, e := range os.Environ() {
 			pair := strings.Split(e, "=")

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 
 		f := fib()
 
-		res := &response{Message: "Hello World!!!!!!!!!!"}
+		res := &response{Message: "Commit Change!!!!!!!!!!"}
 
 		for _, e := range os.Environ() {
 			pair := strings.Split(e, "=")


### PR DESCRIPTION
On the install phase of the buildspec.yaml this command `apt-get update && apt-get -y install jq python3-pip python3-dev && pip3 install --upgrade awscli` was failing to install python 3.4 with the upgraded aws cli 1.19 so I forced it to use aws cli 1.17 and it likes that version, no more errors. 


