### PR TITLE
Updated go image and source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN mkdir -p /go/src/github.com/eks-workshop-sample-api-service-go
 WORKDIR /go/src/github.com/eks-workshop-sample-api-service-go
 RUN useradd -u 10001 app
 COPY . .
+RUN go mod init
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This is a multi-stage build. First we are going to compile and then
 # create a small image for runtime.
-FROM golang:1.11.1 as builder
+FROM public.ecr.aws/bitnami/golang:1.16 as builder
 
 RUN mkdir -p /go/src/github.com/eks-workshop-sample-api-service-go
 WORKDIR /go/src/github.com/eks-workshop-sample-api-service-go


### PR DESCRIPTION
Changed the docker image source
Many EKS workshop users were receiving `toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit`. Changed to a public & trusted source on ECR for the base. 

+ changed from `golang:1.11.1` to `public.ecr.aws/bitnami/golang:1.16`
+ version bump