### PR TITLE
Switched to ECR public gallery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This is a multi-stage build. First we are going to compile and then
 # create a small image for runtime.
-FROM golang:1.11.1 as builder
+FROM public.ecr.aws/docker/library/golang:1.14.11 as builder
 
 RUN mkdir -p /go/src/github.com/eks-workshop-sample-api-service-go
 WORKDIR /go/src/github.com/eks-workshop-sample-api-service-go


### PR DESCRIPTION
Switched to golang version of ECR public gallery to avoid Docker Hub throttle